### PR TITLE
Fix social items in footer.html.twig

### DIFF
--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -24,7 +24,7 @@
                     <h3 class="social">{{ site.footer.social_title }}</h3>
                     <ul>
                         {% for item in site.social %}
-                            <li><a href="{{ item.url }}">{{ item.icon|capitalize }}</a></li>
+                            <li><a href="{{ item.url }}"><i class="fa fa-{{ item.icon }}"></i></a></li>
                         {% endfor %}
                     </ul>
                 </div>


### PR DESCRIPTION
Formats you used in footer.html.twig and social.html.twig were different.
**footer.html.twig:** 
`<li><a href="{{ item.url }}">{{ item.icon|capitalize }}</a></li>`

**social.html.twig:**
` <li><a href="{{ item.url }}"><i class="fa fa-{{ item.icon }}"></i></a></li>`

I assumed footer's twig was incorrect and fixed accordingly.